### PR TITLE
feat: allow extending of base class with params

### DIFF
--- a/scala/class.go
+++ b/scala/class.go
@@ -6,7 +6,7 @@ import (
 
 type ClassDeclaration struct {
 	name       string
-	extends    []string
+	extends    *ExtendsDeclaration
 	modifiers  []string
 	attributes []Writable
 	definition *StatementsDeclaration
@@ -39,9 +39,9 @@ func (self *ClassDeclaration) Abstract() *ClassDeclaration {
 	return self.addModifier("abstract")
 }
 
-func (self *ClassDeclaration) Extends(types ...string) *ClassDeclaration {
-	self.extends = append(self.extends, types...)
-	return self
+func (self *ClassDeclaration) Extends(baseClassName string, params ...string) *ExtendsDeclaration {
+	self.extends = Extends(baseClassName, params...)
+	return self.extends
 }
 
 func (self *ClassDeclaration) Define(block bool) *StatementsDeclaration {
@@ -72,6 +72,7 @@ func Class(name string) *ClassDeclaration {
 		definition: nil,
 		ctor:       nil,
 		isObject:   false,
+		extends:    nil,
 	}
 }
 
@@ -83,6 +84,7 @@ func Object(name string) *ClassDeclaration {
 		definition: nil,
 		ctor:       nil,
 		isObject:   true,
+		extends:    nil,
 	}
 }
 
@@ -109,8 +111,9 @@ func (self *ClassDeclaration) WriteCode(writer CodeWriter) {
 		self.ctor.WriteCode(writer)
 	}
 
-	if len(self.extends) > 0 {
-		writer.Write(" extends " + strings.Join(self.extends, " with "))
+	if self.extends != nil {
+		writer.Write(" ")
+		self.extends.WriteCode(writer)
 	}
 
 	if self.definition != nil {

--- a/scala/class_test.go
+++ b/scala/class_test.go
@@ -11,12 +11,9 @@ func TestClassBasic(t *testing.T) {
 
 func TestClassExtends(t *testing.T) {
 	expected := `class MyClass extends BaseClass`
-	assertCode(t, Class("MyClass").Extends("BaseClass"), expected)
-}
-
-func TestClassExtendsMultiple(t *testing.T) {
-	expected := `class MyClass extends BaseClass with BaseClass2`
-	assertCode(t, Class("MyClass").Extends("BaseClass", "BaseClass2"), expected)
+	result := Class("MyClass")
+	result.Extends("BaseClass")
+	assertCode(t, result, expected)
 }
 
 func TestClassMethod(t *testing.T) {
@@ -90,7 +87,8 @@ func TestEnumCaseObject(t *testing.T) {
 	expected := `
 case object Yes extends Answer { override def toString = "yes" }
 `
-	object := Object("Yes").Case().Extends("Answer")
+	object := Object("Yes").Case()
+	object.Extends("Answer")
 	definition := object.Define(false)
 	definition.Def("toString").Override().NoParams().Define().Add(`"yes"`)
 	assertCode(t, object, expected)

--- a/scala/extends.go
+++ b/scala/extends.go
@@ -1,0 +1,36 @@
+package scala
+
+import "strings"
+
+type ExtendsDeclaration struct {
+	className string
+	params    []string
+	withs     []string
+	code      Writable
+}
+
+func Extends(className string, params ...string) *ExtendsDeclaration {
+	return &ExtendsDeclaration{
+		className: className,
+		params:    params,
+	}
+}
+
+func (self *ExtendsDeclaration) With(traitName string) *ExtendsDeclaration {
+	self.withs = append(self.withs, traitName)
+	return self
+}
+
+func (self *ExtendsDeclaration) WriteCode(writer CodeWriter) {
+	writer.Write("extends " + self.className)
+	if self.params != nil && len(self.params) > 0 {
+		writer.Write("(")
+		writer.Write(strings.Join(self.params, ", "))
+		writer.Write(")")
+	}
+
+	if len(self.withs) > 0 {
+		writer.Write(" with ")
+		writer.Write(strings.Join(self.withs, " with "))
+	}
+}

--- a/scala/extends_test.go
+++ b/scala/extends_test.go
@@ -1,0 +1,26 @@
+package scala
+
+import "testing"
+
+func TestExtendsBaseClassNoParamsNoWiths(t *testing.T) {
+	assertCode(t, Extends("BaseClass"), "extends BaseClass")
+}
+
+func TestExtendsBaseClassAndParamsNoWiths(t *testing.T) {
+	assertCode(t, Extends("BaseClass", "foo", "bar"), "extends BaseClass(foo, bar)")
+}
+
+func TestExtendsBaseClassAndParamsAndWiths(t *testing.T) {
+	assertCode(t, Extends("BaseClass", "foo", "bar").With("BaseTrait"),
+		"extends BaseClass(foo, bar) with BaseTrait")
+}
+
+func TestExtendsBaseClassAndParamsAndMultipleWiths(t *testing.T) {
+	assertCode(t, Extends("BaseClass", "foo", "bar").With("BaseTrait1").With("BaseTrait2"),
+		"extends BaseClass(foo, bar) with BaseTrait1 with BaseTrait2")
+}
+
+func TestExtendsBaseClassAndNoParamsAndMultipleWiths(t *testing.T) {
+	assertCode(t, Extends("BaseClass").With("BaseTrait1").With("BaseTrait2"),
+		"extends BaseClass with BaseTrait1 with BaseTrait2")
+}


### PR DESCRIPTION
@vsapronov 

Currently the `Extends` method of of the `class` in scalagen just appends strings which makes it a bit clunky to extend base classes with constructor parameters. I've broken this out into a separate `ExtendsDeclaration`

Not sure how you feel about this type of enhancement from two perspectives: backwards compatibility and potential over complication of a simple issue. 