### PR TITLE
Don't mutate the stringified enum value

### DIFF
--- a/java/enum.go
+++ b/java/enum.go
@@ -67,7 +67,7 @@ func (cls *EnumDeclaration) WriteCode(writer CodeWriter) {
 			writer.Eol()
 		}
 
-		enumElement := fmt.Sprintf("%s(\"%s\")", memberNameInCode, strings.ToLower(memberNameAsString))
+		enumElement := fmt.Sprintf("%s(\"%s\")", memberNameInCode, memberNameAsString)
 		writer.Write(enumElement)
 		if index < len(cls.enumMembers)-1 {
 			writer.Write(",")


### PR DESCRIPTION
@vsapronov @eugene-yao-zocdoc 

The java enum class should not be mutating the provided string value of the enum